### PR TITLE
Update speed.ts

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,12 +17,12 @@ const QUESTIONS: PromptObject[] = [
       },
       {
         title: 'Classic',
-        description: 'The same speed as the original SNES game (60 px/second).',
+        description: 'Similar speed as the original SNES game (64 px/second).',
         value: WALK_SPEED_CLASSIC,
       },
       {
         title: 'Fast',
-        description: '1.5x faster than the Pixel Remaster default speed (120 px/second)',
+        description: 'Faster than the Pixel Remaster default speed (128 px/second)',
         value: WALK_SPEED_FAST,
       },
     ],

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,12 +17,12 @@ const QUESTIONS: PromptObject[] = [
       },
       {
         title: 'Classic',
-        description: 'Similar speed as the original SNES game (64 px/second).',
+        description: 'Same speed as the original SNES game (60 px/second).',
         value: WALK_SPEED_CLASSIC,
       },
       {
         title: 'Fast',
-        description: 'Faster than the Pixel Remaster default speed (128 px/second)',
+        description: '1.5x faster than the Pixel Remaster default speed (120 px/second)',
         value: WALK_SPEED_FAST,
       },
     ],

--- a/src/ga_constants/speed.ts
+++ b/src/ga_constants/speed.ts
@@ -3,27 +3,27 @@ export const WALK_SPEED_ORIGINAL: WalkSpeed = {
   lookupTable: [
     'c781a400000000008040', // 4.00 (Airship/Sprint)
     'c781a40000009a991940', // 2.40 (Run/Ship)
-    'c781a40000006666e63f', // 1.80 (Chocobo?)
-    'c781a40000009a99993f', // 1.20 (Walkspeed)
+    'c781a40000006666e63f', // 1.80 (Other vehicles e.g. chocobo)
+    'c781a40000009a99993f', // 1.20 (Walkspeed) (Multipliers for FF5/6 start with c783a4 instead of c781a4, need their own separate tools.)
   ],
 };
 
 export const WALK_SPEED_CLASSIC: WalkSpeed = {
-  base: '9a99993e', // 0.3 (64pps) (Runs a bit smoother than before based on testing, else set to 0.32 for true 60pps, bearing in mind there does seem to be grid position snapping)
+  base: '0ad7a33e', // 0.32 (60pps based on 1.2 multiplier)
   lookupTable: [
     'c781a40000009a999940', // 4.80 (Airship/Sprint)
     'c781a40000009a991940', // 2.40 (Run/Ship)
-    'c781a40000006666e63f', // 1.80 (Chocobo?) (This may need to stay at 1.8 instead of 1.2, could have been causing the fucky speeds)
+    'c781a40000006666e63f', // 1.80 (Other vehicles) (This needs to stay at 1.8 instead of 1.2)
     'c781a40000009a99993f', // 1.20 (Walkspeed)
   ],
 };
 
 export const WALK_SPEED_FAST: WalkSpeed = {
-  base: '9a99193e', // 0.15 (128pps) (Runs a bit smoother than before based on testing, else set to 0.16 for true 120pps)
+  base: '0ad7233e', // 0.16 (120pps based on 1.2 multiplier)
   lookupTable: [
     'c781a40000009a999940', // 4.80 (Airship/Sprint)
     'c781a40000009a991940', // 2.40 (Run/Ship)
-    'c781a40000006666e63f', // 1.80 (Chocobo?)
+    'c781a40000006666e63f', // 1.80 (Other vehicles)
     'c781a40000009a99993f', // 1.20 (Walkspeed)
   ],
 };

--- a/src/ga_constants/speed.ts
+++ b/src/ga_constants/speed.ts
@@ -1,30 +1,30 @@
 export const WALK_SPEED_ORIGINAL: WalkSpeed = {
-  base: '8fc2753e', // 0.24
+  base: '8fc2753e', // 0.24 (80pps)
   lookupTable: [
-    'c781a400000000008040', // 4.00
-    'c781a40000009a991940', // 2.40
-    'c781a40000006666e63f', // 1.80
-    'c781a40000009a99993f', // 1.20
+    'c781a400000000008040', // 4.00 (Airship/Sprint)
+    'c781a40000009a991940', // 2.40 (Run/Ship)
+    'c781a40000006666e63f', // 1.80 (Chocobo?)
+    'c781a40000009a99993f', // 1.20 (Walkspeed)
   ],
 };
 
 export const WALK_SPEED_CLASSIC: WalkSpeed = {
-  base: '2db29d3e', // 0.308
+  base: '9a99993e', // 0.3 (64pps) (Runs a bit smoother than before based on testing, else set to 0.32 for true 60pps, bearing in mind there does seem to be grid position snapping)
   lookupTable: [
-    'c781a40000009a999940', // 4.80
-    'c781a40000009a991940', // 2.40
-    'c781a40000009a99993f', // 1.20
-    'c781a40000009a99993f', // 1.20
+    'c781a40000009a999940', // 4.80 (Airship/Sprint)
+    'c781a40000009a991940', // 2.40 (Run/Ship)
+    'c781a40000006666e63f', // 1.80 (Chocobo?) (This may need to stay at 1.8 instead of 1.2, could have been causing the fucky speeds)
+    'c781a40000009a99993f', // 1.20 (Walkspeed)
   ],
 };
 
 export const WALK_SPEED_FAST: WalkSpeed = {
-  base: 'd0611e3e', // 0.15467
+  base: '9a99193e', // 0.15 (128pps) (Runs a bit smoother than before based on testing, else set to 0.16 for true 120pps)
   lookupTable: [
-    'c781a40000009a999940', // 4.80
-    'c781a40000009a991940', // 2.40
-    'c781a40000009a99993f', // 1.20
-    'c781a40000009a99993f', // 1.20
+    'c781a40000009a999940', // 4.80 (Airship/Sprint)
+    'c781a40000009a991940', // 2.40 (Run/Ship)
+    'c781a40000006666e63f', // 1.80 (Chocobo?)
+    'c781a40000009a99993f', // 1.20 (Walkspeed)
   ],
 };
 


### PR DESCRIPTION
Added labels, changed the base numbers for classic and fast, changed the 1.2 multipliers above walk speed back to the original 1.8. Things seem smoother now, but haven't tested vehicles not present in FF1.